### PR TITLE
Update Tailwind CSS to the latest version (1.4.4)

### DIFF
--- a/template.json
+++ b/template.json
@@ -9,12 +9,10 @@
       "@types/react-dom": "^16.9.0",
       "@types/jest": "^24.0.0",
       "typescript": "~3.7.2",
-      "@fullhuman/postcss-purgecss": "^2.0.6",
       "cross-env": "^7.0.0",
       "cssnano": "^4.1.10",
       "postcss-cli": "^7.1.0",
       "postcss-preset-env": "^6.7.0",
-      "purgecss": "^2.0.6",
       "tailwindcss": "^1.4.4",
       "npm-run-all": "^4.1.5"
     },

--- a/template.json
+++ b/template.json
@@ -15,7 +15,7 @@
       "postcss-cli": "^7.1.0",
       "postcss-preset-env": "^6.7.0",
       "purgecss": "^2.0.6",
-      "tailwindcss": "^1.2.0",
+      "tailwindcss": "^1.4.4",
       "npm-run-all": "^4.1.5"
     },
     "scripts": {

--- a/template/postcss.config.js
+++ b/template/postcss.config.js
@@ -1,22 +1,6 @@
-const purgecss = require('@fullhuman/postcss-purgecss')({
-  // Specify the paths to all of the template files in your project
-  content: [
-    './src/**/*.html',
-    './src/**/*.js',
-    './src/**/*.jsx',
-    './src/**/*.ts',
-    './src/**/*.tsx',
-    './public/index.html',
-  ],
-
-  // Include any special characters you're using in this regular expression
-  defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
-});
-
 module.exports = {
   plugins: [
     require('tailwindcss'),
     require('postcss-preset-env'),
-    ...(process.env.NODE_ENV === 'production' ? [purgecss] : []),
   ],
 };

--- a/template/src/styles/tailwind.css
+++ b/template/src/styles/tailwind.css
@@ -1,7 +1,5 @@
-/* purgecss start ignore */
 @tailwind base;
 
 @tailwind components;
-/* purgecss end ignore */
 
 @tailwind utilities;

--- a/template/src/styles/tailwind.css
+++ b/template/src/styles/tailwind.css
@@ -1,5 +1,15 @@
 @tailwind base;
 
-@tailwind components;
+/* Your own custom base styles */
 
+/* Start purging... */
+@tailwind components;
+/* Stop purging. */
+
+/* Your own custom component styles */
+
+/* Start purging... */
 @tailwind utilities;
+/* Stop purging. */
+
+/* Your own custom utilities */

--- a/template/tailwind.config.js
+++ b/template/tailwind.config.js
@@ -3,5 +3,20 @@ module.exports = {
     extend: {}
   },
   variants: {},
-  plugins: []
+  plugins: [],
+  purge: {
+    // Filenames to scan for classes
+    content: [
+      './src/**/*.html',
+      './src/**/*.js',
+      './src/**/*.jsx',
+      './src/**/*.ts',
+      './src/**/*.tsx',
+      './public/index.html',
+    ],
+    // Options passed to PurgeCSS
+    options: {
+        whitelist: [],
+    },
+  },
 }

--- a/template/tailwind.config.js
+++ b/template/tailwind.config.js
@@ -16,7 +16,8 @@ module.exports = {
     ],
     // Options passed to PurgeCSS
     options: {
-        whitelist: [],
+      // Whitelist specific selectors by name
+      // whitelist: [],
     },
   },
 }


### PR DESCRIPTION
Version 1.4.0 adds built-in support for PurgeCSS: https://github.com/tailwindcss/tailwindcss/releases/tag/v1.4.0

The `@fullhuman/postcss-purgecss` and `purgecss` dependencies aren't needed anymore, so I removed them.